### PR TITLE
feat: add support for toBeDeepEqual in test scripts

### DIFF
--- a/packages/hoppscotch-js-sandbox/README.md
+++ b/packages/hoppscotch-js-sandbox/README.md
@@ -49,6 +49,14 @@ cd hoppscotch/packages/hoppscotch-js-sandbox
 npm run demo
 ```
 
+## Developement Setup - Gary Ascuy
+
+Tests does not work with nodejs 20, it's required nodejs flag
+
+```sh
+NODE_OPTIONS="--no-node-snapshot" pnpm test
+```
+
 ## Versioning
 This project follows [Semantic Versioning](https://semver.org/) but as the project is still pre-1.0. The code and the public exposed API should not be considered to be fixed and stable. Things can change at any time!
 

--- a/packages/hoppscotch-js-sandbox/README.md
+++ b/packages/hoppscotch-js-sandbox/README.md
@@ -55,6 +55,9 @@ Tests does not work with nodejs 20, it's required nodejs flag
 
 ```sh
 NODE_OPTIONS="--no-node-snapshot" pnpm test
+
+# root
+NODE_OPTIONS="--no-node-snapshot" pnpm run --filter  js-sandbox test
 ```
 
 ## Versioning

--- a/packages/hoppscotch-js-sandbox/package.json
+++ b/packages/hoppscotch-js-sandbox/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "lint": "eslint --ext .ts,.js --ignore-path .gitignore .",
     "lintfix": "eslint --fix --ext .ts,.js --ignore-path .gitignore .",
-    "test": "vitest run",
+    "test": "NODE_OPTIONS=\"--no-node-snapshot\" vitest run",
     "build": "vite build && tsc --emitDeclarationOnly",
     "clean": "pnpm tsc --build --clean",
     "postinstall": "pnpm run build",

--- a/packages/hoppscotch-js-sandbox/src/__tests__/expect/toBeDeepEqual.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/expect/toBeDeepEqual.spec.ts
@@ -22,18 +22,60 @@ describe("toBeDeepEqual", () => {
   describe("general assertion (no negation)", () => {
     test("expect equals expected passes assertion", () => {
       return expect(
-        func(
-          `
-            pw.expect({}).toBeDeepEqual({})
-          `,
-          fakeResponse
-        )()
+        func(`pw.expect({}).toBeDeepEqual({})`, fakeResponse)()
       ).resolves.toEqualRight([
         expect.objectContaining({
           expectResults: [
             {
               status: "pass",
               message: "Expected '{}' to be '{}'",
+            },
+          ],
+        }),
+      ])
+    })
+
+    test("expect not equals expected fails assertion", () => {
+      return expect(
+        func(`pw.expect({name: "gary"}).toBeDeepEqual({})`, fakeResponse)()
+      ).resolves.toEqualRight([
+        expect.objectContaining({
+          expectResults: [
+            {
+              status: "fail",
+              message: "Expected '{\"name\":\"gary\"}' to be '{}'",
+            },
+          ],
+        }),
+      ])
+    })
+  })
+
+  describe("general assertion (with negation)", () => {
+    test("expect equals expected fails assertion", () => {
+      return expect(
+        func(`pw.expect({}).not.toBeDeepEqual({})`, fakeResponse)()
+      ).resolves.toEqualRight([
+        expect.objectContaining({
+          expectResults: [
+            {
+              status: "fail",
+              message: "Expected '{}' to not be '{}'",
+            },
+          ],
+        }),
+      ])
+    })
+
+    test("expect not equals expected passes assertion", () => {
+      return expect(
+        func(`pw.expect({}).not.toBeDeepEqual({name: "gory"})`, fakeResponse)()
+      ).resolves.toEqualRight([
+        expect.objectContaining({
+          expectResults: [
+            {
+              status: "pass",
+              message: "Expected '{}' to not be '{\"name\":\"gory\"}'",
             },
           ],
         }),

--- a/packages/hoppscotch-js-sandbox/src/__tests__/expect/toBeDeepEqual.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/expect/toBeDeepEqual.spec.ts
@@ -1,0 +1,43 @@
+import * as TE from "fp-ts/TaskEither"
+import { pipe } from "fp-ts/function"
+
+import { describe, expect, test } from "vitest"
+
+import { runTestScript } from "~/node"
+import { TestResponse } from "~/types"
+
+const fakeResponse: TestResponse = {
+  status: 200,
+  body: "hoi",
+  headers: [],
+}
+
+const func = (script: string, res: TestResponse) =>
+  pipe(
+    runTestScript(script, { global: [], selected: [] }, res),
+    TE.map((x) => x.tests)
+  )
+
+describe("toBeDeepEqual", () => {
+  describe("general assertion (no negation)", () => {
+    test("expect equals expected passes assertion", () => {
+      return expect(
+        func(
+          `
+            pw.expect({}).toBeDeepEqual({})
+          `,
+          fakeResponse
+        )()
+      ).resolves.toEqualRight([
+        expect.objectContaining({
+          expectResults: [
+            {
+              status: "pass",
+              message: "Expected '[object Object]' to be '[object Object]'",
+            },
+          ],
+        }),
+      ])
+    })
+  })
+})

--- a/packages/hoppscotch-js-sandbox/src/__tests__/expect/toBeDeepEqual.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/expect/toBeDeepEqual.spec.ts
@@ -33,7 +33,7 @@ describe("toBeDeepEqual", () => {
           expectResults: [
             {
               status: "pass",
-              message: "Expected '[object Object]' to be '[object Object]'",
+              message: "Expected '{}' to be '{}'",
             },
           ],
         }),

--- a/packages/hoppscotch-js-sandbox/src/__tests__/expect/toBeDeepEqual.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/expect/toBeDeepEqual.spec.ts
@@ -35,6 +35,25 @@ describe("toBeDeepEqual", () => {
       ])
     })
 
+    test("expect equals expected passes assertion with many values in different order", () => {
+      return expect(
+        func(`
+          const expectedValue = {name: "gary", age: 666, nick: "gory"};
+          const actualValue = {age: 666, name: "gary", nick: "gory"};
+          pw.expect(expectedValue).toBeDeepEqual(actualValue)
+        `, fakeResponse)()
+      ).resolves.toEqualRight([
+        expect.objectContaining({
+          expectResults: [
+            {
+              status: "pass",
+              message: "Expected '{\"name\":\"gary\",\"age\":666,\"nick\":\"gory\"}' to be '{\"age\":666,\"name\":\"gary\",\"nick\":\"gory\"}'",
+            },
+          ],
+        }),
+      ])
+    })
+
     test("expect not equals expected fails assertion", () => {
       return expect(
         func(`pw.expect({name: "gary"}).toBeDeepEqual({})`, fakeResponse)()
@@ -76,6 +95,82 @@ describe("toBeDeepEqual", () => {
             {
               status: "pass",
               message: "Expected '{}' to not be '{\"name\":\"gory\"}'",
+            },
+          ],
+        }),
+      ])
+    })
+  })
+
+  describe("general nested objects assertion (no negation)", () => {
+    test("expect equals expected passes assertion", () => {
+      return expect(
+        func(`
+          const expected = {name: "gary", info: { age: 666, tesed: true }};
+          const actual = {info: { tesed: true, age: 666 }, name: "gary"}
+          pw.expect(expected).toBeDeepEqual(actual)`, fakeResponse)()
+      ).resolves.toEqualRight([
+        expect.objectContaining({
+          expectResults: [
+            {
+              status: "pass",
+              message: "Expected '{\"name\":\"gary\",\"info\":{\"age\":666,\"tesed\":true}}' to be '{\"info\":{\"tesed\":true,\"age\":666},\"name\":\"gary\"}'",
+            },
+          ],
+        }),
+      ])
+    })
+
+    test("expect not equals expected fails assertion", () => {
+      return expect(
+        func(`
+          const expected = {name: "gory", info: { age: 666, tesed: true }};
+          const actual = {info: { tesed: true, age: 666 }, name: "gary"}
+          pw.expect(expected).toBeDeepEqual(actual)`, fakeResponse)()
+      ).resolves.toEqualRight([
+        expect.objectContaining({
+          expectResults: [
+            {
+              status: "fail",
+              message: "Expected '{\"name\":\"gory\",\"info\":{\"age\":666,\"tesed\":true}}' to be '{\"info\":{\"tesed\":true,\"age\":666},\"name\":\"gary\"}'",
+            },
+          ],
+        }),
+      ])
+    })
+  })
+
+  describe("general nested objects assertion (with negation)", () => {
+    test("expect equals expected passes assertion", () => {
+      return expect(
+        func(`
+          const expected = {name: "gary", info: { age: 666, tesed: true }};
+          const actual = {info: { tesed: true, age: 666 }, name: "gory"}
+          pw.expect(expected).not.toBeDeepEqual(actual)`, fakeResponse)()
+      ).resolves.toEqualRight([
+        expect.objectContaining({
+          expectResults: [
+            {
+              status: "pass",
+              message: "Expected '{\"name\":\"gary\",\"info\":{\"age\":666,\"tesed\":true}}' to not be '{\"info\":{\"tesed\":true,\"age\":666},\"name\":\"gory\"}'",
+            },
+          ],
+        }),
+      ])
+    })
+
+    test("expect not equals expected fails assertion", () => {
+      return expect(
+        func(`
+          const expected = {name: "gary", info: { age: 666, tesed: true }};
+          const actual = {info: { tesed: true, age: 666 }, name: "gary"}
+          pw.expect(expected).not.toBeDeepEqual(actual)`, fakeResponse)()
+      ).resolves.toEqualRight([
+        expect.objectContaining({
+          expectResults: [
+            {
+              status: "fail",
+              message: "Expected '{\"name\":\"gary\",\"info\":{\"age\":666,\"tesed\":true}}' to not be '{\"info\":{\"tesed\":true,\"age\":666},\"name\":\"gary\"}'",
             },
           ],
         }),

--- a/packages/hoppscotch-js-sandbox/src/node/test-runner.ts
+++ b/packages/hoppscotch-js-sandbox/src/node/test-runner.ts
@@ -141,6 +141,7 @@ const executeScriptInContext = (
               // Serialize matcher methods for use in the isolate context
               const matcherMethodNames = [
                 "toBe",
+                "toBeDeepEqual",
                 "toBeLevel2xx",
                 "toBeLevel3xx",
                 "toBeLevel4xx",

--- a/packages/hoppscotch-js-sandbox/src/shared-utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/shared-utils.ts
@@ -229,7 +229,32 @@ export function preventCyclicObjects(
   }
 }
 
-export const isDeepEqual = (_a: unknown, _b: unknown): boolean => {
+export const isObject = (object: unknown): boolean => {
+  return object != null && typeof object === "object"
+}
+
+export const isDeepEqual = (object1: any, object2: any): boolean => {
+  const objKeys1 = Object.keys(object1)
+  const objKeys2 = Object.keys(object2)
+
+  if (objKeys1.length !== objKeys2.length) {
+    return false
+  }
+
+  for (const key of objKeys1) {
+    const value1 = object1[key]
+    const value2 = object2[key]
+
+    const isObjects = isObject(value1) && isObject(value2)
+
+    if (
+      (isObjects && !isDeepEqual(value1, value2)) ||
+      (!isObjects && value1 !== value2)
+    ) {
+      return false
+    }
+  }
+
   return true
 }
 

--- a/packages/hoppscotch-js-sandbox/src/shared-utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/shared-utils.ts
@@ -229,6 +229,10 @@ export function preventCyclicObjects(
   }
 }
 
+export const isDeepEqual = (_a: unknown, _b: unknown): boolean => {
+  return true
+}
+
 /**
  * Creates an Expectation object for use inside the sandbox
  * @param expectVal The expecting value of the expectation
@@ -444,7 +448,7 @@ export const createExpectation = (
   }
 
   const toBeDeepEqualFn = (expectedVal: any) => {
-    let assertion = resolvedExpectVal === expectedVal
+    let assertion = isDeepEqual(resolvedExpectVal, expectedVal)
 
     if (negated) {
       assertion = !assertion

--- a/packages/hoppscotch-js-sandbox/src/shared-utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/shared-utils.ts
@@ -233,6 +233,10 @@ export const isObject = (object: unknown): boolean => {
   return object != null && typeof object === "object"
 }
 
+export const toJson = (object: any): string => {
+  return JSON.stringify(object, null, 0)
+}
+
 export const isDeepEqual = (object1: any, object2: any): boolean => {
   const objKeys1 = Object.keys(object1)
   const objKeys2 = Object.keys(object2)
@@ -480,9 +484,9 @@ export const createExpectation = (
     }
 
     const status = assertion ? "pass" : "fail"
-    const message = `Expected '${resolvedExpectVal}' to${
+    const message = `Expected '${toJson(resolvedExpectVal)}' to${
       negated ? " not" : ""
-    } be '${expectedVal}'`
+    } be '${toJson(expectedVal)}'`
 
     currTestStack[currTestStack.length - 1].expectResults.push({
       status,

--- a/packages/hoppscotch-js-sandbox/src/shared-utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/shared-utils.ts
@@ -443,7 +443,7 @@ export const createExpectation = (
     return undefined
   }
 
-  const toDeepEqualFn = (expectedVal: any) => {
+  const toBeDeepEqualFn = (expectedVal: any) => {
     let assertion = resolvedExpectVal === expectedVal
 
     if (negated) {
@@ -463,8 +463,8 @@ export const createExpectation = (
     return undefined
   }
 
-
   result.toBe = toBeFn
+  result.toBeDeepEqual = toBeDeepEqualFn
   result.toBeLevel2xx = toBeLevel2xxFn
   result.toBeLevel3xx = toBeLevel3xxFn
   result.toBeLevel4xx = toBeLevel4xxFn
@@ -472,7 +472,6 @@ export const createExpectation = (
   result.toBeType = toBeTypeFn
   result.toHaveLength = toHaveLengthFn
   result.toInclude = toIncludeFn
-  result.toDeepEqual = toDeepEqualFn
 
   Object.defineProperties(result, {
     not: {

--- a/packages/hoppscotch-js-sandbox/src/shared-utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/shared-utils.ts
@@ -443,6 +443,27 @@ export const createExpectation = (
     return undefined
   }
 
+  const toDeepEqualFn = (expectedVal: any) => {
+    let assertion = resolvedExpectVal === expectedVal
+
+    if (negated) {
+      assertion = !assertion
+    }
+
+    const status = assertion ? "pass" : "fail"
+    const message = `Expected '${resolvedExpectVal}' to${
+      negated ? " not" : ""
+    } be '${expectedVal}'`
+
+    currTestStack[currTestStack.length - 1].expectResults.push({
+      status,
+      message,
+    })
+
+    return undefined
+  }
+
+
   result.toBe = toBeFn
   result.toBeLevel2xx = toBeLevel2xxFn
   result.toBeLevel3xx = toBeLevel3xxFn
@@ -451,6 +472,7 @@ export const createExpectation = (
   result.toBeType = toBeTypeFn
   result.toHaveLength = toHaveLengthFn
   result.toInclude = toIncludeFn
+  result.toDeepEqual = toDeepEqualFn
 
   Object.defineProperties(result, {
     not: {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
- add toBeDeepEqual method into test scripts

```ts
const expected = {name: "gary", info: { age: 666, tesed: true }};
const actual = {info: { tesed: true, age: 666 }, name: "gary"}
pw.expect(expected).toBeDeepEqual(actual)
```

### Unit Tests
<img width="921" alt="image" src="https://github.com/user-attachments/assets/50d825bd-19a8-485e-ad85-02e8a6db1d1a" />


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
